### PR TITLE
Private channel authorization response problem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 1.6 - March 2015
+
+* Swift and 64-bit compatibility
+* Added new delegate method to support extracting auth response from wrapped payloads (#171)
+* Removed SocketRocket from the public interface (#157)
+* Fix deprecation warning for willAuthorizeChannelWithRequest (#147)
+* Use NSDate instead of C API for setting timestamp on auth request (#133)
+
 # 1.5 - December 2013
 
 This release contains some significant bug fixes and API changes. All deprecated API in this release will be removed in the next release after this one.

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -281,6 +281,9 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 {
   [channel authorizeWithCompletionHandler:^(BOOL isAuthorized, NSDictionary *authData, NSError *error) {
     if (isAuthorized && self.connection.isConnected) {
+      if ([self.delegate respondsToSelector:@selector(pusher:authorizationPayloadFromResponseData:)]) {
+        authData = [self.delegate pusher:self authorizationPayloadFromResponseData:authData];
+      }    
       [channel subscribeWithAuthorization:authData];
     }
     else {

--- a/Library/PTPusherDelegate.h
+++ b/Library/PTPusherDelegate.h
@@ -109,6 +109,21 @@
  */
 - (void)pusher:(PTPusher *)pusher willAuthorizeChannel:(PTPusherChannel *)channel withRequest:(NSMutableURLRequest *)request;
 
+/** Allows the delegate to return authorization data in the format required by Pusher from a
+ non-standard respnse.
+ 
+ When using a remote server to authorize access to a private channel, the server is expected to 
+ return an authorization payload in a specific format which is then sent to Pusher when connecting
+ to a private channel.
+ 
+ Sometimes, a server might return a non-standard response, for example, the auth data may be a sub-set
+ of some bigger response.
+ 
+ If implemented, Pusher will call this method with the response data returned from the authorization
+ URL and will use whatever dictionary is returned instead.
+*/
+ - (NSDictionary *)pusher:(PTPusher *)pusher authorizationPayloadFromResponseData:(NSDictionary *)responseData;
+
 /** Notifies the delegate that the PTPusher instance has subscribed to the specified channel.
  
  This method will be called after any channel authorization has taken place and when a subscribe event has been received.

--- a/libPusher.xcodeproj/project.pbxproj
+++ b/libPusher.xcodeproj/project.pbxproj
@@ -384,8 +384,10 @@
 				A315780A14D0751C000136A9 /* Pods.xcconfig */,
 				A31577F714D0731B000136A9 /* Pods-specs.xcconfig */,
 			);
+			indentWidth = 2;
 			name = CustomTemplate;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Im attempting to use this library with an application backed by Parse.com, and am running into an issue with the authorization flow. 

Parse wraps all of its cloud code responses in a "result" key, so the auth response from the server looks like {"result": {"auth": <signature> }}. 

This seems to be keeping authorization attempts from working. Any way to specify how the server response should be parsed?

PS: I'm new to pusher, so there's a distinct possibility that in approaching this the wrong way. 

Thanks!