### PR TITLE
use instancetype in factory methods where possible

### DIFF
--- a/Library/PTJSON.m
+++ b/Library/PTJSON.m
@@ -10,7 +10,7 @@
 #import "PTPusherMacros.h"
 
 @interface PTNSJSONParser : NSObject <PTJSONParser>
-+ (id)NSJSONParser;
++ (instancetype)NSJSONParser;
 @end
 
 @implementation PTJSON
@@ -24,7 +24,7 @@
 
 @implementation PTNSJSONParser 
 
-+ (id)NSJSONParser
++ (instancetype)NSJSONParser
 {
   PT_DEFINE_SHARED_INSTANCE_USING_BLOCK(^{
     return [[self alloc] init];

--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -144,7 +144,7 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  @param delegate    The delegate for this instance
  @param isEncrypted If yes, a secure connection over SSL will be established.
  */
-+ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted;
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted;
 
 /** Returns a new PTPusher instance with a connection configured with the given key and allows to set different cluster
 
@@ -154,7 +154,7 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  @param cluster     If set, connects to the provided cluster
  */
 
-+ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster;
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster;
 
 /** Returns a new PTPusher instance with an connection configured with the given key.
  
@@ -164,7 +164,7 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  @param key       Your application's API key. It can be found in the API Access section of your application within the Pusher user dashboard.
  @param delegate  The delegate for this instance
  */
-+ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate;
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate;
 
 ///------------------------------------------------------------------------------------/
 /// @name Managing the connection

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -93,17 +93,17 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
   return self;
 }
 
-+ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate
 {
   return [self pusherWithKey:key delegate:delegate encrypted:YES];
 }
 
-+ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted
 {
   return [self pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) nil];
 }
 
-+ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster
 {
     NSString * hostURL;
     if ([cluster length] == 0) {

--- a/Library/PTPusherChannel.h
+++ b/Library/PTPusherChannel.h
@@ -72,7 +72,7 @@
  */
 @property (nonatomic, readonly) BOOL isPresence;
 
-+ (id)channelWithName:(NSString *)name pusher:(PTPusher *)pusher;
++ (instancetype)channelWithName:(NSString *)name pusher:(PTPusher *)pusher;
 - (id)initWithName:(NSString *)channelName pusher:(PTPusher *)pusher;
 - (void)authorizeWithCompletionHandler:(void(^)(BOOL, NSDictionary *, NSError *))completionHandler;
 

--- a/Library/PTPusherChannel.m
+++ b/Library/PTPusherChannel.m
@@ -32,7 +32,7 @@
 
 @implementation PTPusherChannel
 
-+ (id)channelWithName:(NSString *)name pusher:(PTPusher *)pusher
++ (instancetype)channelWithName:(NSString *)name pusher:(PTPusher *)pusher
 {
   if ([name hasPrefix:@"private-"]) {
     return [[PTPusherPrivateChannel alloc] initWithName:name pusher:pusher];

--- a/Library/PTPusherEvent.h
+++ b/Library/PTPusherEvent.h
@@ -43,7 +43,7 @@ extern NSString *const PTPusherChannelKey;
 @property (nonatomic, readonly, strong) NSDate *timeReceived;
 
 - (id)initWithEventName:(NSString *)name channel:(NSString *)channel data:(id)data;
-+ (id)eventFromMessageDictionary:(NSDictionary *)dictionary;
++ (instancetype)eventFromMessageDictionary:(NSDictionary *)dictionary;
 
 @end
 

--- a/Library/PTPusherEvent.m
+++ b/Library/PTPusherEvent.m
@@ -15,7 +15,7 @@ NSString *const PTPusherChannelKey = @"channel";
 
 @implementation PTPusherEvent
 
-+ (id)eventFromMessageDictionary:(NSDictionary *)dictionary
++ (instancetype)eventFromMessageDictionary:(NSDictionary *)dictionary
 {
   if ([dictionary[PTPusherEventKey] isEqualToString:@"pusher:error"]) {
     return [[PTPusherErrorEvent alloc] initWithEventName:dictionary[PTPusherEventKey] channel:nil data:dictionary[PTPusherDataKey]];


### PR DESCRIPTION
See: http://stackoverflow.com/questions/8972221/

`instancetype` makes it explicit that such method returns an instance of the given class and not an object that can be anything. This is especially important when using the code from Swift, since without this you need to explicitly cast the object to the given type before using it.
