### PR TITLE
Allow creation Pusher client with an explicit host name.

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -153,8 +153,16 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  @param isEncrypted If yes, a secure connection over SSL will be established.
  @param cluster     If set, connects to the provided cluster
  */
-
 + (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster;
+
+/** Returns a new PTPusher instance with a connection configured with the given key and allows to set different cluster
+
+ @param key         Your application's API key. It can be found in the API Access section of your application within the Pusher user dashboard.
+ @param delegate    The delegate for this instance
+ @param isEncrypted If yes, a secure connection over SSL will be established.
+ @param host        Pusher fully qualified domain name.
+ */
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted host:(NSString *)host;
 
 /** Returns a new PTPusher instance with an connection configured with the given key.
  

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -103,16 +103,21 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
   return [self pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) nil];
 }
 
-+ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *)cluster
 {
-    NSString * hostURL;
+    NSString *host;
     if ([cluster length] == 0) {
-        hostURL = kPUSHER_HOST;
+        host = kPUSHER_HOST;
     } else {
-        hostURL = [NSString stringWithFormat:@"ws-%@.pusher.com", cluster];
+        host = [NSString stringWithFormat:@"ws-%@.pusher.com", cluster];
     }
 
-    NSURL *serviceURL = PTPusherConnectionURL(hostURL, key, @"libPusher", isEncrypted);
+    return [self pusherWithKey:key delegate:delegate encrypted:isEncrypted host:host];
+}
+
++ (instancetype)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted host:(NSString *)host
+{
+    NSURL *serviceURL = PTPusherConnectionURL(host, key, @"libPusher", isEncrypted);
     PTPusherConnection *connection = [[PTPusherConnection alloc] initWithURL:serviceURL];
     PTPusher *pusher = [[self alloc] initWithConnection:connection];
     pusher.delegate = delegate;


### PR DESCRIPTION
We're moving to a dedicated cluster with Pusher, and need to be able to configure the client with an explicit hostname. Exposing this constructor sort of mirrors the Android library, as well, which has a `setHost` method (https://github.com/pusher/pusher-websocket-java#the-pusher-constructor).