### PR TITLE
Runtime API endpoints change

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -42,6 +42,8 @@ extern NSString *const PTPusherFatalErrorDomain;
  */
 extern NSString *const PTPusherErrorUnderlyingEventKey;
 
+extern NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, BOOL encrypted);
+
 @class PTPusherChannel;
 @class PTPusherPresenceChannel;
 @class PTPusherPrivateChannel;

--- a/Library/PTPusherAPI.h
+++ b/Library/PTPusherAPI.h
@@ -36,6 +36,8 @@
  */
 - (id)initWithKey:(NSString *)aKey appID:(NSString *)anAppID secretKey:(NSString *)aSecretKey;
 
+- (void)setHost:(NSString *)value;
+
 ///------------------------------------------------------------------------------------/
 /// @name Triggering events
 ///------------------------------------------------------------------------------------/

--- a/Library/PTPusherAPI.m
+++ b/Library/PTPusherAPI.m
@@ -17,6 +17,8 @@
 
 @implementation PTPusherAPI {
   NSString *key, *appID, *secretKey;
+  NSString *host;
+  NSInteger port;
   NSOperationQueue *operationQueue;
 }
 
@@ -27,10 +29,14 @@
     appID = [anAppID copy];
     secretKey = [aSecretKey copy];
     operationQueue = [[NSOperationQueue alloc] init];
+    host = kPUSHER_API_DEFAULT_HOST;
   }
   return self;
 }
 
+- (void)setHost:(NSString *)value {
+    host = value;
+}
 
 - (void)triggerEvent:(NSString *)eventName onChannel:(NSString *)channelName data:(id)eventData socketID:(NSString *)socketID
 {
@@ -54,7 +60,7 @@
   
   queryParameters[@"auth_signature"] = [signatureString HMACDigestUsingSecretKey:secretKey];
   
-  NSString *URLString = [NSString stringWithFormat:@"http://%@%@?%@", kPUSHER_API_DEFAULT_HOST, path, [queryParameters sortedQueryString]];
+  NSString *URLString = [NSString stringWithFormat:@"http://%@%@?%@", host, path, [queryParameters sortedQueryString]];
   
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:URLString]];
   [request setHTTPBody:bodyData];


### PR DESCRIPTION
Instead of compile-time `kPUSHER_API_DEFAULT_HOST ` use `.host` property (which is equal to `kPUSHER_API_DEFAULT_HOST ` by default)