### PR TITLE
Moved post of PTPusherEventReceivedNotification

### DIFF
--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -375,6 +375,10 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 
 - (void)pusherConnection:(PTPusherConnection *)connection didReceiveEvent:(PTPusherEvent *)event
 {
+  [[NSNotificationCenter defaultCenter] 
+     postNotificationName:PTPusherEventReceivedNotification
+     object:self 
+     userInfo:@{PTPusherEventUserInfoKey: event}];
   if ([event isKindOfClass:[PTPusherErrorEvent class]]) {
     if ([self.delegate respondsToSelector:@selector(pusher:didReceiveErrorEvent:)]) {
       [self.delegate pusher:self didReceiveErrorEvent:(PTPusherErrorEvent *)event];
@@ -385,11 +389,6 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
     [channels[event.channel] dispatchEvent:event];
   }
   [dispatcher dispatchEvent:event];
-  
-  [[NSNotificationCenter defaultCenter] 
-     postNotificationName:PTPusherEventReceivedNotification
-     object:self 
-     userInfo:@{PTPusherEventUserInfoKey: event}];
 }
 
 - (void)handleDisconnection:(PTPusherConnection *)connection error:(NSError *)error reconnectMode:(PTPusherAutoReconnectMode)reconnectMode


### PR DESCRIPTION
fixes https://github.com/lukeredpath/libPusher/issues/191

Now, the notification gets posted before the event is dispatched or the delegate is notified in case it's an error-event